### PR TITLE
Depends refactored

### DIFF
--- a/lib/config-parser.js
+++ b/lib/config-parser.js
@@ -245,6 +245,14 @@ function parseInteger(value /* , context */) {
     return parseInt(value, 10);
 }
 
+function parseDepends(value, context) {
+    try {
+        return requestParser.select(value, { enableBraces: true });
+    } catch (err) {
+        throw new ImplementationError(err.message + context.errorContext);
+    }
+}
+
 function checkResourceName(name, context) {
     if (!/^[a-zA-Z_][a-zA-Z_\-0-9/]*$/.test(name)) {
         throw new ImplementationError(`Invalid resource name "${name}"${context.errorContext}`);
@@ -711,6 +719,7 @@ function processNode(attrNode, context) {
                     subFilters: parseSubFilters,
                     resource: checkResourceName,
                     primaryKey: parsePrimaryKey,
+                    depends: parseDepends,
                     deprecated: parseBoolean,
                     permission: null,
                     attributes: null,
@@ -731,6 +740,7 @@ function processNode(attrNode, context) {
                     parentKey: parseRelationKey,
                     childKey: parseRelationKey,
                     many: parseBoolean,
+                    depends: parseDepends,
                     hidden: parseBoolean,
                     deprecated: parseBoolean,
                     permission: null,
@@ -751,7 +761,7 @@ function processNode(attrNode, context) {
         parseNode(
             attrNode,
             {
-                depends: requestParser.select,
+                depends: parseDepends,
                 hidden: parseBoolean,
                 deprecated: parseBoolean,
                 permission: null,
@@ -780,7 +790,7 @@ function processNode(attrNode, context) {
                 filter: parseFilter,
                 order: parseOrder,
                 value: parseStaticValue,
-                depends: requestParser.select,
+                depends: parseDepends,
                 hidden: parseBoolean,
                 deprecated: parseBoolean,
                 permission: null,

--- a/lib/request-resolver.js
+++ b/lib/request-resolver.js
@@ -27,8 +27,6 @@ function mergeSubResource(attrNode, subResourceConfig, context) {
     // Merge options from sub-resource to parent (order is irrelevant here):
     Object.keys(subResourceConfig).forEach(optionName => {
         if (optionName === 'attributes') {
-            if (!attrNode._attrsRefs) attrNode._attrsRefs = [];
-            attrNode._attrsRefs.push(subResourceConfig.attributes);
             if (!attrNode.attributes) attrNode.attributes = {};
         } else if (optionName === 'dataSources') {
             const newDataSources = Object.assign({}, subResourceConfig.dataSources);
@@ -65,6 +63,9 @@ function mergeSubResource(attrNode, subResourceConfig, context) {
             attrNode[optionName] = subResourceConfig[optionName];
         }
     });
+
+    attrNode._origNodes = attrNode._origNodes || [];
+    attrNode._origNodes.push(subResourceConfig);
 }
 
 /**
@@ -123,12 +124,12 @@ function resolveIncludes(attrNode, context) {
 function getAttribute(path, attrNode, context) {
     path.forEach((attributeName, i) => {
         if (!(attrNode.attributes && attrNode.attributes[attributeName])) {
-            if (attrNode._attrsRefs) {
+            if (attrNode._origNodes) {
                 let subAttrNode = null;
-                attrNode._attrsRefs.forEach(attrsRef => {
-                    if (!attrsRef[attributeName]) return;
+                attrNode._origNodes.forEach((origNode, inheritDepth) => {
+                    if (!origNode || !origNode.attributes || !origNode.attributes[attributeName]) return;
 
-                    const attrRef = attrsRef[attributeName];
+                    let origSubAttrNode = origNode.attributes[attributeName];
 
                     if (subAttrNode) {
                         if (subAttrNode.inherit === 'inherit') {
@@ -145,21 +146,24 @@ function getAttribute(path, attrNode, context) {
                         subAttrNode = {};
                     }
 
-                    Object.keys(attrRef).forEach(optionName => {
+                    Object.keys(origSubAttrNode).forEach(optionName => {
                         if (subAttrNode.hasOwnProperty(optionName)) return; // for inherit
 
                         if (optionName === 'attributes') {
-                            subAttrNode._attrsRefs = [attrRef.attributes];
                             subAttrNode[optionName] = {};
                         } else if (optionName === 'dataSources') {
                             // DataSources are handled/cloned later in resolveResourceTree():
-                            subAttrNode[optionName] = attrRef[optionName];
-                        } else if (typeof attrRef[optionName] === 'object') {
-                            subAttrNode[optionName] = cloneDeep(attrRef[optionName]);
+                            subAttrNode[optionName] = origSubAttrNode[optionName];
+                        } else if (typeof origSubAttrNode[optionName] === 'object') {
+                            subAttrNode[optionName] = cloneDeep(origSubAttrNode[optionName]);
                         } else {
-                            subAttrNode[optionName] = attrRef[optionName];
+                            subAttrNode[optionName] = origSubAttrNode[optionName];
                         }
                     });
+
+                    // keep the inherit-depth (array length) from parent:
+                    subAttrNode._origNodes = subAttrNode._origNodes || Array(attrNode._origNodes.length);
+                    subAttrNode._origNodes[inheritDepth] = origSubAttrNode;
 
                     attrNode.attributes[attributeName] = subAttrNode;
                 });
@@ -200,9 +204,13 @@ function resolveDependencies(req, attrNode, context, dependency, dependencyConte
     let isDep = !!dependency;
     dependency = dependency || {};
     dependencyContext = Object.assign({}, dependencyContext || {});
+    dependencyContext.inheritDepth = dependencyContext.inheritDepth || 0;
 
-    if (attrNode.resourceName || !dependencyContext.absolute) {
-        dependencyContext.absolute = { req, attrNode, context };
+    // remember all contexts for absolute "depends" for included/merged sub-resources:
+    while (dependencyContext.inheritDepth < attrNode._origNodes.length) {
+        dependencyContext.absolute = dependencyContext.absolute ? dependencyContext.absolute.slice() : [];
+        dependencyContext.absolute[dependencyContext.inheritDepth] = { req, attrNode, context };
+        dependencyContext.inheritDepth++;
     }
 
     if (attrNode.dataSources || !dependencyContext.relative) {
@@ -257,7 +265,10 @@ function resolveDependencies(req, attrNode, context, dependency, dependencyConte
             let dependency = { select: { [subAttrName]: attrNode.depends[subAttrName] } };
 
             if (subAttrName === '{root}') {
-                refContext = dependencyContext.absolute;
+                // use correct absolute context for included/merged sub-resources based on where "depends" was specified:
+                // TODO: maybe process ALL original "depends"-options here (even when "overwritten" by merge):
+                let inheritDepth = attrNode._origNodes.findIndex(origNode => origNode && 'depends' in origNode);
+                refContext = dependencyContext.absolute[inheritDepth];
                 dependency = attrNode.depends[subAttrName];
             }
 

--- a/lib/request-resolver.js
+++ b/lib/request-resolver.js
@@ -185,70 +185,78 @@ function getAttribute(path, attrNode, context) {
 }
 
 /**
- * @private
- */
-function mergeRequest(req, dependency, attrNode, context) {
-    if (dependency.select) {
-        const subContext = Object.assign({}, context);
-        if (!req.select) req.select = {};
-
-        Object.keys(dependency.select).forEach(subAttrName => {
-            const subAttrNode = getAttribute([subAttrName], attrNode, context);
-            subContext.attrPath = context.attrPath.concat([subAttrName]);
-
-            if (!req.select[subAttrName]) {
-                req.select[subAttrName] = cloneDeep(dependency.select[subAttrName]);
-                // it is enough to set the root of selected sub-nodes to "internal = true",
-                // because result-builder will not follow this node anyway then, so we leave
-                // the sub-nodes well alone:
-                req.select[subAttrName].internal = true;
-
-                if (subAttrNode.depends) {
-                    // resolve dependency of dependency:
-                    mergeRequest(
-                        context.refRequest,
-                        { select: subAttrNode.depends },
-                        context.refAttrNode,
-                        context.refContext
-                    );
-                }
-            } else {
-                mergeRequest(req.select[subAttrName], dependency.select[subAttrName], subAttrNode, subContext);
-            }
-        });
-    }
-}
-
-/**
- * Merge dependencies of selected attributes within current (sub-)resource into request and handle
- * recursive dependencies.
+ * Merge all dependencies into request (with "internal"-flag).
+ *
+ * Features:
+ * - recursive dependencies
+ * - resource-absolute dependencies (depends="{root}.foo.bar")
+ * - datasource-relative (depends="foo.bar")
+ * - proper handling of cyclic dependencies
+ * - helpful error messages with context
  *
  * @private
  */
-function resolveDependencies(req, attrNode, context) {
-    if (!context.refRequest) {
-        // remember (sub-)resource-root because all dependencies are relative to it:
-        context = Object.assign({}, context);
-        context.refRequest = req;
-        context.refAttrNode = attrNode;
-        context.refContext = context;
+function resolveDependencies(req, attrNode, context, dependency, dependencyContext) {
+    let isDep = !!dependency;
+    dependency = dependency || {};
+    dependencyContext = Object.assign({}, dependencyContext || {});
+
+    if (attrNode.resourceName || !dependencyContext.absolute) {
+        dependencyContext.absolute = { req, attrNode, context };
     }
 
-    if (attrNode.depends) {
-        // we resolve dependencies (and sub-dependencies) in place. Only unprocessed
-        // attributes are resolved again inside mergeRequest(), so we do not enter
-        // endless recursion on cyclic dependencies:
-        mergeRequest(context.refRequest, { select: attrNode.depends }, context.refAttrNode, context.refContext);
+    if (attrNode.dataSources || !dependencyContext.relative) {
+        dependencyContext.relative = { req, attrNode, context };
     }
 
-    if (req.select) {
-        const subContext = Object.assign({}, context);
-        Object.keys(req.select).forEach(subAttrName => {
-            const subAttrNode = getAttribute([subAttrName], attrNode, context);
-            if (subAttrNode.dataSources) return;
+    if ((!isDep && req.select) || (isDep && dependency.select)) {
+        let subContext = Object.assign({}, context);
+        let subDependencyContext = Object.assign({}, dependencyContext);
+
+        Object.keys(isDep ? dependency.select : req.select).forEach(subAttrName => {
+            let subAttrNode = getAttribute([subAttrName], attrNode, context);
             subContext.attrPath = context.attrPath.concat([subAttrName]);
+            subDependencyContext.skipDepends = false;
 
-            resolveDependencies(req.select[subAttrName], subAttrNode, subContext);
+            if (isDep) {
+                if (!req.select) req.select = {};
+                if (!req.select[subAttrName]) req.select[subAttrName] = { internal: true };
+                else subDependencyContext.skipDepends = true; // no re-entry for cyclic dependencys
+            }
+
+            resolveDependencies(
+                req.select[subAttrName],
+                subAttrNode,
+                subContext,
+                isDep ? dependency.select[subAttrName] : null,
+                subDependencyContext
+            );
+        });
+    }
+
+    if (attrNode.depends && !dependencyContext.skipDepends) {
+        dependencyContext.skipDepends = true; // relative/absolute context root-node is always already processed
+
+        Object.keys(attrNode.depends).forEach(subAttrName => {
+            let refContext = dependencyContext.relative;
+            let dependency = { select: { [subAttrName]: attrNode.depends[subAttrName] } };
+
+            if (subAttrName === '{root}') {
+                refContext = dependencyContext.absolute;
+                dependency = attrNode.depends[subAttrName];
+            }
+
+            try {
+                resolveDependencies(
+                    refContext.req,
+                    refContext.attrNode,
+                    refContext.context,
+                    dependency,
+                    dependencyContext
+                );
+            } catch (err) {
+                throw new ImplementationError(err.message + ' in "depends" in ' + context.attrPath.join('.'));
+            }
         });
     }
 }
@@ -732,11 +740,6 @@ function mapRequestRecursive(req, attrNode, context) {
         }
     }
 
-    // merge all dependencies (within current resource) into request (with "internal"-flag), before
-    // we call ourself recursive, because this function is not designed to be called multiple times
-    // for the same attrNode:
-    if (attrNode.dataSources) resolveDependencies(req, attrNode, context);
-
     // tree recursion:
     if (req.select) {
         const subContext = Object.assign({}, context);
@@ -1119,6 +1122,7 @@ module.exports = function requestResolver(req, resourceConfigs) {
     };
 
     resolveIncludes(resolvedConfig, context);
+    resolveDependencies(req, resolvedConfig, context);
     const resourceTree = mapRequestRecursive(req, resolvedConfig, context);
     const dataSourceTree = resolveResourceTree(resourceTree);
 

--- a/lib/request-resolver.js
+++ b/lib/request-resolver.js
@@ -209,6 +209,21 @@ function resolveDependencies(req, attrNode, context, dependency, dependencyConte
         dependencyContext.relative = { req, attrNode, context };
     }
 
+    // always select primaryKey:
+    if (attrNode.primaryKey) {
+        attrNode.primaryKey.forEach(primaryKeyAttrPath => {
+            let primaryKeyAttrNode = getAttribute(primaryKeyAttrPath, attrNode, context);
+
+            primaryKeyAttrPath.reduce((subReq, subAttrName) => {
+                // Object.assign-"hack" for correct attribute order (primary key always first):
+                subReq.select = Object.assign({ [subAttrName]: {} }, subReq.select || {});
+                subReq.select[subAttrName].isPrimary = true;
+
+                if (primaryKeyAttrNode.hidden) subReq.select[subAttrName].internal = true;
+            }, req);
+        });
+    }
+
     if ((!isDep && req.select) || (isDep && dependency.select)) {
         let subContext = Object.assign({}, context);
         let subDependencyContext = Object.assign({}, dependencyContext);
@@ -598,34 +613,6 @@ function mapRequestRecursive(req, attrNode, context) {
 
         if (attrNode.primaryKey && attrNode.resolvedPrimaryKey) {
             subResourceTree.primaryKey = attrNode.resolvedPrimaryKey;
-
-            // always select primaryKey:
-            attrNode.primaryKey.forEach(primaryKeyAttrPath => {
-                const primaryKeyAttrNode = getAttribute(primaryKeyAttrPath, attrNode, context);
-
-                if (!primaryKeyAttrNode.hidden && !req.internal) {
-                    primaryKeyAttrNode.selected = true;
-
-                    if (attrNode.permission || authContext) {
-                        try {
-                            if (!context.auth || !context.auth.check)
-                                throw new ImplementationError(`No valid Auth-Provider available`);
-                            context.auth.check(primaryKeyAttrNode, authContext);
-                        } catch (err) {
-                            err.message += ` at "${context.attrPath.concat(primaryKeyAttrPath).join('.')}"`;
-                            throw err;
-                        }
-                    }
-                }
-
-                subResourceTree.attributes.push({
-                    dataSourceMap: primaryKeyAttrNode.map.default,
-                    attrNode: primaryKeyAttrNode,
-                    fromDataSource: '#all-selected'
-                });
-            });
-
-            context.useRequestError = true;
         }
 
         let isMainResource = true;
@@ -729,6 +716,7 @@ function mapRequestRecursive(req, attrNode, context) {
         // error handling: only "select" is possible on non-resource-nodes:
         let optionsCount = Object.keys(req).length;
         if ('select' in req) optionsCount--;
+        if ('isPrimary' in req) optionsCount--;
         if ('internal' in req) optionsCount--;
 
         if (optionsCount > 0) {
@@ -736,7 +724,9 @@ function mapRequestRecursive(req, attrNode, context) {
         }
 
         if (attrNode.map) {
-            context.resourceTree.attributes.push({ dataSourceMap: attrNode.map.default, attrNode });
+            let attribute = { dataSourceMap: attrNode.map.default, attrNode };
+            if (req.isPrimary) attribute.fromDataSource = '#all-selected';
+            context.resourceTree.attributes.push(attribute);
         }
     }
 

--- a/lib/request-resolver.js
+++ b/lib/request-resolver.js
@@ -91,7 +91,7 @@ function resolveIncludes(attrNode, context) {
 
         if (!context.resourceConfigs[attrNode.resource] || !context.resourceConfigs[attrNode.resource].config) {
             if (context.attrPath.length === 0 && includeStack.length === 1) {
-                throw new RequestError('Unknown resource "' + attrNode.resource + '" in request');
+                throw new RequestError('Unknown resource "' + attrNode.resource + '"');
             } else {
                 throw new ImplementationError(
                     'Unknown resource "' +
@@ -167,7 +167,7 @@ function getAttribute(path, attrNode, context) {
 
             if (!(attrNode.attributes && attrNode.attributes[attributeName])) {
                 throw new RequestError(
-                    'Unknown attribute ' + `"${context.attrPath.concat(path.slice(0, i + 1)).join('.')}" in request`
+                    'Unknown attribute ' + `"${context.attrPath.concat(path.slice(0, i + 1)).join('.')}"`
                 );
             }
         }
@@ -557,9 +557,7 @@ function processRequestOptions(req, attrNode, context) {
 function mapRequestRecursive(req, attrNode, context) {
     if (attrNode.hidden && !req.internal) {
         throw new RequestError(
-            ['Unknown attribute "' + context.attrPath.join('.') + '"', 'in request - it is a hidden attribute'].join(
-                ' '
-            )
+            ['Unknown attribute "' + context.attrPath.join('.') + '" - it is a hidden attribute'].join(' ')
         );
     }
 
@@ -1105,7 +1103,7 @@ function resolveResourceTree(resourceTree, parentDataSourceName) {
  * @return {Object}
  */
 module.exports = function requestResolver(req, resourceConfigs) {
-    if (!req.resource) throw new RequestError('Resource not specified in request');
+    if (!req.resource) throw new RequestError('Resource not specified');
 
     // init recursion:
     const resolvedConfig = { resource: req.resource, many: true };

--- a/lib/result-builder.js
+++ b/lib/result-builder.js
@@ -187,8 +187,9 @@ function buildItem(parentAttrNode, row, context) {
     Object.keys(parentAttrNode.attributes).forEach(attrName => {
         const attrNode = parentAttrNode.attributes[attrName];
 
-        if (context.useSelectedInternal) {
+        if (context.selectedInternalLevel > 0) {
             if (!attrNode.selectedInternal) return;
+            if (!attrNode.selectedInternal[context.selectedInternalLevel - 1]) return;
         } else if (!attrNode.selected) return;
 
         if (attrNode.attributes) {
@@ -338,38 +339,42 @@ function buildItem(parentAttrNode, row, context) {
                         context
                     ),
                 buildItem: attributes => {
-                    function selectInternal(isSelected) {
+                    const maxRecursionLevel = 20;
+
+                    function selectInternal(level, isSelected) {
                         attributes.forEach(attribute => {
                             let attrNode = parentAttrNode;
-                            let selectedInternalBefore;
-
                             attribute.forEach(attrName => {
                                 if (!(attrNode.attributes && attrNode.attributes[attrName])) {
                                     let attrStr = attribute.join('.');
                                     throw new ImplementationError(
-                                        `Result-Builder (item-extension/buildItem): Unknown attribute "${attrStr}"`
+                                        `item-extension/buildItem: Unknown attribute "${attrStr}"`
                                     );
                                 }
                                 attrNode = attrNode.attributes[attrName];
-                                selectedInternalBefore = attrNode.selectedInternal;
-                                attrNode.selectedInternal = isSelected;
-                            });
 
-                            if (isSelected && selectedInternalBefore) {
-                                let attrStr = attribute.join('.');
-                                throw new ImplementationError(
-                                    `Result-Builder (item-extension/buildItem): Invalid recursion for "${attrStr}"`
-                                );
-                            }
+                                if (!attrNode.selectedInternal) {
+                                    // we use a flag per recursion level to handle recursive buildItem calls independently
+                                    attrNode.selectedInternal = new Array(maxRecursionLevel).fill(false);
+                                }
+                                attrNode.selectedInternal[level - 1] = isSelected;
+                            });
                         });
                     }
 
                     const subContext = Object.assign({}, context);
-                    subContext.useSelectedInternal = true;
+                    subContext.selectedInternalLevel++;
 
-                    selectInternal(true);
+                    if (subContext.selectedInternalLevel > maxRecursionLevel) {
+                        let attrStr = attributes.map(attribute => attribute.join('.')).join(',');
+                        throw new ImplementationError(
+                            `item-extension/buildItem: Recursion depth for "${attrStr}" too big`
+                        );
+                    }
+
+                    selectInternal(subContext.selectedInternalLevel, true);
                     const internalItem = buildItem(parentAttrNode, row, subContext);
-                    selectInternal(false);
+                    selectInternal(subContext.selectedInternalLevel, false);
 
                     return internalItem;
                 }
@@ -402,7 +407,7 @@ module.exports = function resultBuilder(api, request, rawResults, resolvedConfig
         attrPath: [], // current path from root
         primaryKey: null, // current primary key
         secondaryRows: null, // current row of all DataSources (by primary key)
-        useSelectedInternal: false // used for buildItem() in item-extension
+        selectedInternalLevel: 0 // used for (recursive) buildItem() in item-extension
     };
 
     // determine primary result of main resource to iterate over at root level:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "content-type": "^1.0.2",
     "flora-cluster": "^2.0.0-alpha.2",
     "flora-errors": "^2.0.0-alpha.1",
-    "flora-request-parser": "^2.0.0",
+    "flora-request-parser": "^2.1.0",
     "has": "^1.0.3",
     "lodash": "^4.17.11",
     "moment-timezone": "^0.5.23",

--- a/test/fixtures/resolved-config.json
+++ b/test/fixtures/resolved-config.json
@@ -296,26 +296,6 @@
                     "selected": false,
                     "selectedDataSource": "primary"
                 },
-                "articleId": {
-                    "hidden": true,
-                    "type": "int",
-                    "map": {
-                        "default": {
-                            "articleCategories": "articleId"
-                        }
-                    },
-                    "selectedDataSource": "articleCategories"
-                },
-                "categoryId": {
-                    "hidden": true,
-                    "type": "int",
-                    "map": {
-                        "default": {
-                            "articleCategories": "categoryId"
-                        }
-                    },
-                    "selectedDataSource": "articleCategories"
-                },
                 "name": {
                     "map": {
                         "default": {
@@ -334,6 +314,26 @@
                         }
                     },
                     "selected": false,
+                    "selectedDataSource": "articleCategories"
+                },
+                "articleId": {
+                    "hidden": true,
+                    "type": "int",
+                    "map": {
+                        "default": {
+                            "articleCategories": "articleId"
+                        }
+                    },
+                    "selectedDataSource": "articleCategories"
+                },
+                "categoryId": {
+                    "hidden": true,
+                    "type": "int",
+                    "map": {
+                        "default": {
+                            "articleCategories": "categoryId"
+                        }
+                    },
                     "selectedDataSource": "articleCategories"
                 }
             },
@@ -387,8 +387,8 @@
                     "database": "contents",
                     "table": "country",
                     "attributes": [
-                        "id",
                         "iso",
+                        "id",
                         "name"
                     ],
                     "filter": [
@@ -416,15 +416,6 @@
                     "selected": false,
                     "selectedDataSource": "primary"
                 },
-                "iso": {
-                    "map": {
-                        "default": {
-                            "primary": "iso"
-                        }
-                    },
-                    "type": "string",
-                    "selectedDataSource": "primary"
-                },
                 "name": {
                     "map": {
                         "default": {
@@ -433,6 +424,15 @@
                     },
                     "type": "string",
                     "selected": false,
+                    "selectedDataSource": "primary"
+                },
+                "iso": {
+                    "map": {
+                        "default": {
+                            "primary": "iso"
+                        }
+                    },
+                    "type": "string",
                     "selectedDataSource": "primary"
                 }
             },
@@ -597,8 +597,8 @@
                     "database": "contents",
                     "table": "article_comment",
                     "attributes": [
-                        "id",
                         "articleId",
+                        "id",
                         "content",
                         "userId"
                     ],
@@ -626,16 +626,6 @@
                         "equal"
                     ],
                     "selected": false,
-                    "selectedDataSource": "primary"
-                },
-                "articleId": {
-                    "hidden": true,
-                    "type": "int",
-                    "map": {
-                        "default": {
-                            "primary": "articleId"
-                        }
-                    },
                     "selectedDataSource": "primary"
                 },
                 "content": {
@@ -738,6 +728,16 @@
                     },
                     "selected": false,
                     "primaryDataSource": "primary"
+                },
+                "articleId": {
+                    "hidden": true,
+                    "type": "int",
+                    "map": {
+                        "default": {
+                            "primary": "articleId"
+                        }
+                    },
+                    "selectedDataSource": "primary"
                 },
                 "userId": {
                     "hidden": true,

--- a/test/request-resolver.spec.js
+++ b/test/request-resolver.spec.js
@@ -88,7 +88,7 @@ describe('request-resolver', () => {
 
             expect(() => {
                 requestResolver(req, resourceConfigs);
-            }).to.throw(RequestError, 'Resource not specified in request');
+            }).to.throw(RequestError, 'Resource not specified');
         });
 
         it('fails on unknown resource in request', () => {
@@ -96,7 +96,7 @@ describe('request-resolver', () => {
 
             expect(() => {
                 requestResolver(req, resourceConfigs);
-            }).to.throw(RequestError, 'Unknown resource "non-existing" in request');
+            }).to.throw(RequestError, 'Unknown resource "non-existing"');
         });
 
         it('fails on unknown included resource with different error', () => {
@@ -463,7 +463,7 @@ describe('request-resolver', () => {
 
             expect(() => {
                 requestResolver(req, resourceConfigs);
-            }).to.throw(RequestError, 'Unknown attribute "invalid" in request');
+            }).to.throw(RequestError, 'Unknown attribute "invalid"');
         });
 
         it('fails when selecting unknown sub-attributes', () => {
@@ -481,7 +481,7 @@ describe('request-resolver', () => {
 
             expect(() => {
                 requestResolver(req, resourceConfigs);
-            }).to.throw(RequestError, 'Unknown attribute "title.invalid" in request');
+            }).to.throw(RequestError, 'Unknown attribute "title.invalid"');
         });
 
         it('fails when selecting hidden attributes', () => {
@@ -495,7 +495,7 @@ describe('request-resolver', () => {
 
             expect(() => {
                 requestResolver(req, resourceConfigs);
-            }).to.throw(RequestError, 'Unknown attribute "secretInfo" in request - it is a hidden attribute');
+            }).to.throw(RequestError, 'Unknown attribute "secretInfo" - it is a hidden attribute');
         });
 
         it('resolves request with filter', () => {

--- a/test/request-resolver.spec.js
+++ b/test/request-resolver.spec.js
@@ -253,7 +253,7 @@ describe('request-resolver', () => {
                 }
             };
 
-            const expectedOrder = ['attr3', 'attr2', 'attr1', 'id'];
+            const expectedOrder = ['id', 'attr3', 'attr2', 'attr1'];
 
             const resolvedRequest = requestResolver(req, configs);
             const currentOrder = Object.keys(resolvedRequest.resolvedConfig.attributes['resource2'].attributes);
@@ -1204,7 +1204,7 @@ describe('request-resolver', () => {
                             type: 'mysql',
                             database: 'contents',
                             table: 'article_comment',
-                            attributes: ['id', 'articleId', 'content'],
+                            attributes: ['articleId', 'id', 'content'],
                             filter: [[{ attribute: 'articleId', operator: 'equal', valueFromParentKey: true }]]
                         },
                         attributeOptions: {
@@ -1260,7 +1260,7 @@ describe('request-resolver', () => {
                             type: 'mysql',
                             database: 'contents',
                             table: 'article_comment',
-                            attributes: ['id', 'articleId', 'content'],
+                            attributes: ['articleId', 'id', 'content'],
                             filter: [[{ attribute: 'articleId', operator: 'equal', valueFromParentKey: true }]]
                         },
                         attributeOptions: {
@@ -1395,7 +1395,7 @@ describe('request-resolver', () => {
                             type: 'mysql',
                             database: 'contents',
                             table: 'country',
-                            attributes: ['id', 'iso', 'name'],
+                            attributes: ['iso', 'id', 'name'],
                             filter: [[{ attribute: 'iso', operator: 'equal', valueFromParentKey: true }]]
                         },
                         attributeOptions: {
@@ -1528,7 +1528,7 @@ describe('request-resolver', () => {
                             type: 'mysql',
                             database: 'contents',
                             table: 'article_comment',
-                            attributes: ['id', 'articleId'],
+                            attributes: ['articleId', 'id'],
                             filter: [
                                 [
                                     { attribute: 'id', operator: 'equal', value: 3 },


### PR DESCRIPTION
- supports absolute deps now via depends="{root}.foo.bar" inside inline-sub-resources
- supports deps on (sub-)resource nodes now
- full recursion support in buildItem()
- fixes some architecture-related issues from old algorithm