### PR TITLE
Replace moment-timezone with luxon

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -4,7 +4,7 @@ const bunyan = require('bunyan');
 const PromiseEventEmitter = require('promise-events');
 const { Status } = require('flora-cluster');
 const { NotFoundError, RequestError } = require('flora-errors');
-const moment = require('moment-timezone');
+const { Info } = require('luxon');
 
 const asciiArtProfile = require('./ascii-art-profile');
 const ResourceProcessor = require('./resource-processor');
@@ -116,9 +116,10 @@ class Api extends PromiseEventEmitter {
         }
 
         if (this.config.timezone) {
-            const zone = moment.tz.zone(this.config.timezone);
-            if (!zone) throw new Error(`Timezone "${this.config.timezone}" does not exist`);
-            this.log.debug(`Using timezone "${zone.name}"`);
+            if (!Info.isValidIANAZone(this.config.timezone)) {
+                throw new Error(`Timezone "${this.config.timezone}" does not exist`);
+            }
+            this.log.debug(`Using timezone "${this.config.timezone}"`);
         } else {
             this.log.debug('No timezone is set, using default "UTC"');
         }

--- a/lib/cast.js
+++ b/lib/cast.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const moment = require('moment-timezone');
-const { DataError, ImplementationError } = require('flora-errors');
+const { DateTime } = require('luxon');
+const { DataError } = require('flora-errors');
 
 const casts = {};
 
@@ -35,28 +35,27 @@ function parseDatetime(value, options, api) {
             ? options.storedType.options.timezone
             : defaultStoredTz;
 
-    if (!moment.tz.zone(storedTz)) throw new ImplementationError(`Invalid timezone: "${storedTz}"`);
-
-    let m;
+    let dt;
     if (options && options.storedType && options.storedType.type === 'unixtime') {
-        m = moment(parseInt(value, 10), 'X');
+        dt = DateTime.fromSeconds(parseInt(value, 10));
     } else {
-        m = moment.tz(value, moment.ISO_8601, true, storedTz);
+        // Default format is SQL
+        dt = DateTime.fromSQL(value, { zone: storedTz });
+        // Fall back to ISO 8601
+        if (!dt.isValid) dt = DateTime.fromISO(value, { zone: storedTz });
     }
 
-    if (!m.isValid()) throw new DataError('Invalid date format');
+    if (!dt.isValid) throw new DataError(`Invalid date format: ${dt.invalidReason}`);
 
-    return m;
+    return dt;
 }
 
 casts.datetime = (value, options, api) => {
     const apiTz = api && api.config && api.config.timezone ? api.config.timezone : 'UTC';
 
     try {
-        const m = parseDatetime(value, options, api);
-        if (apiTz === 'UTC') return m.toISOString();
-        m.tz(apiTz);
-        return m.format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+        const dt = parseDatetime(value, options, api).setZone(apiTz);
+        return dt.toISO();
     } catch (e) {
         // api.log.warn(`cannot parse date: "${value}": ${e.message}`);
         return null;
@@ -65,8 +64,8 @@ casts.datetime = (value, options, api) => {
 
 casts.date = (value, options, api) => {
     try {
-        const m = parseDatetime(value, options, api);
-        return m.format('YYYY-MM-DD');
+        const dt = parseDatetime(value, options, api);
+        return dt.toISODate();
     } catch (e) {
         // api.log.warn(`cannot parse date: "${value}": ${e.message}`);
         return null;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.pick": "^4.4.0",
     "lodash.uniq": "^4.5.0",
-    "moment-timezone": "^0.5.33",
+    "luxon": "^1.25.0",
     "promise-events": "^0.2.4",
     "serve-static": "^1.14.1",
     "@xmldom/xmldom": "^0.7.5"


### PR DESCRIPTION
Moment.js is being [considered legacy](https://momentjs.com/docs/#/-project-status/) (aka. "done"). There are modern alternatives, especially for Node.js, like [Luxon](https://moment.github.io/luxon).

This PR replaces `moment-timezone` with `luxon`.

However, Luxon is more strict in terms of parsing strings, especially where Moment.js could parse ISO dates ("2016-05-25T09:24:15") and SQL dates ("2017-05-15 09:24:15") equally. This is now achived by using `fromSQL` by default and falling back to `fromISO`, but we need to look carefully if all edge cases are covered by this.