### PR TITLE
request-resolver: resolve "limitPer/limit/page" to joinDataSource for m:n relations

### DIFF
--- a/lib/request-resolver.js
+++ b/lib/request-resolver.js
@@ -1178,6 +1178,22 @@ function resolveResourceTree(resourceTree, parentDataSourceName) {
             ]
         ];
 
+        if (dataSourceTree.request.limitPer) {
+            // resolve "limitPer/limit/page" to joinDataSource for m:n relations (maybe limit/page should ALWAYS be
+            // resolved to joinDataSource but this will break requests with a single parent and e.g. "order=name"),
+            // which currently works as expected - but is inconsistent behaviour.
+
+            const limitPer = joinDataSource.resolvedJoinParentKey;
+            joinDataSource.limitPer = limitPer.length === 1 ? limitPer[0] : limitPer;
+            delete dataSourceTree.request.limitPer;
+
+            joinDataSource.limit = dataSourceTree.request.limit;
+            delete dataSourceTree.request.limit;
+
+            joinDataSource.page = dataSourceTree.request.page;
+            delete dataSourceTree.request.page;
+        }
+
         const originalDataSourceTree = dataSourceTree;
         dataSourceTree = {
             attributePath: resourceTree.attrPath,


### PR DESCRIPTION
For m:n relations "limitPer/limit/page" has to be resolved to the m:n query, not to the sub-resource.

Example: /country/?select=id,countries(limit=5)(order=name:asc).name&filter=id=539,542

But there is still no solution to get "order=name:asc" working - because in the m:n query we don't have the name. So we only resolve it to joinDataSource if we have multiple parents to be (hopefully) backward compatible - but it is inconsistent behaviour.