### PR TITLE
url-parser: parse HTTP body to _httpRequest

### DIFF
--- a/lib/url-parser.js
+++ b/lib/url-parser.js
@@ -89,6 +89,7 @@ function httpToFloraRequest(httpRequest) {
                                 opts[key] = payload[key];
                             }
                         });
+                        if (!httpRequest.body) httpRequest.body = payload;
                     } else if (contentTypes.type === 'application/json') {
                         try {
                             opts.data = JSON.parse(payload);
@@ -96,6 +97,7 @@ function httpToFloraRequest(httpRequest) {
                             reject(new RequestError('Invalid payload, must be valid JSON'));
                             return;
                         }
+                        if (!httpRequest.body) httpRequest.body = opts.data;
                     }
 
                     resolve(new Request(opts));

--- a/test/url-parser.spec.js
+++ b/test/url-parser.spec.js
@@ -164,6 +164,8 @@ describe('HTTP request parsing', () => {
             parseRequest(httpRequest)
                 .then((request) => {
                     expect(request.data).to.have.property('a', true);
+                    expect(request._httpRequest).to.have.property('body');
+                    expect(request._httpRequest.body).to.have.property('a', true);
                     done();
                 })
                 .catch(done);
@@ -180,6 +182,9 @@ describe('HTTP request parsing', () => {
                 .then((request) => {
                     expect(request).to.have.property('a', 'true');
                     expect(request).to.have.property('b', 'false');
+                    expect(request._httpRequest).to.have.property('body');
+                    expect(request._httpRequest.body).to.have.property('a', 'true');
+                    expect(request._httpRequest.body).to.have.property('b', 'false');
                     done();
                 })
                 .catch(done);


### PR DESCRIPTION
This mirrors the behaviour of expressjs/body-parser and allows the body data to be passed on to error handling if necessary.

Caveat: the request._httpRequest object is changed (body property is added), but if it already exists it is not overwritten.