### PR TITLE
feat: pass through Error.data on errors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -207,6 +207,8 @@ class Server {
      */
     _sendError(err, httpRequest, httpResponse) {
         const response = new Response();
+
+        if (err.data) response.data = err.data;
         if (err.meta) Object.assign(response.meta, err.meta);
         response.meta.statusCode = err.httpStatusCode || new errors.FloraError().httpStatusCode;
         response.error = errors.format(err, { exposeErrors: this.api.config.exposeErrors });


### PR DESCRIPTION
Allows to pass through data in case of errors:

```js
const err = new RequestError('foo');
err.data = { foo: 'bar' };
throw err;
```

It would also be possible to just use the `response.data` in case of an error (if set), but I guess this might lead to unexpected behaviour when data is returned when it shouldn't.